### PR TITLE
Bump release on main branch to 6.0.4.1

### DIFF
--- a/travis/globals.sh
+++ b/travis/globals.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -x
-RELEASE_TAG="6.0.3.3"
+RELEASE_TAG="6.0.4.1"
 export RELEASE_TAG
 DATE_TAG=$(date +"%m%d%y")
 TRAVIS_TAG_WITH_UPSTREAM_ID=${TRAVIS_TAG}.${UPSTREAM_ID}


### PR DESCRIPTION
Stable branch lmr-6.0.3 was created for 6.0.3.x releases.